### PR TITLE
[31기 홍두현] modify : 상단 nav merge 후 레이아웃 깨짐 현상 수정

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -28,7 +28,7 @@ const Nav = () => {
     return () => {
       window.removeEventListener('scroll', scrollFixed);
     };
-  }, []);
+  });
 
   const isMainPage = location.pathname === '/';
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import NAV_LIST from './navData';
 import './Nav.scss';
 
 const Nav = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [navActive, setNavActive] = useState(false);
   const [scrollY, setScrollY] = useState(0);
   const [scrollActive, setScrollActive] = useState(false);
@@ -27,51 +28,56 @@ const Nav = () => {
     return () => {
       window.removeEventListener('scroll', scrollFixed);
     };
-  });
+  }, []);
+
+  const isMainPage = location.pathname === '/';
 
   return (
-    <div className={`nav${scrollActive ? ' fixed' : ''}`}>
-      <ul className="navUtil inner">
-        <li>로그인</li>
-        <li>회원가입</li>
-        <li>
-          <span className="instagram">인스타</span>
-          <span className="facebook">페이스북</span>
-        </li>
-      </ul>
-      <div
-        className="navWrap inner"
-        onMouseLeave={() => {
-          setNavActive(false);
-        }}
-      >
-        <h1 className="logo">로고이미지</h1>
-        <ul
-          className={`navListWrap${navActive ? ' active' : ''}`}
-          onMouseEnter={() => {
-            setNavActive(true);
+    <>
+      <div className={`nav${scrollActive ? ' fixed' : ''}`}>
+        <ul className="navUtil inner">
+          <li>로그인</li>
+          <li>회원가입</li>
+          <li>
+            <span className="instagram">인스타</span>
+            <span className="facebook">페이스북</span>
+          </li>
+        </ul>
+        <div
+          className="navWrap inner"
+          onMouseLeave={() => {
+            setNavActive(false);
           }}
         >
-          {NAV_LIST.map(item => (
-            <li className="navList" key={item.id}>
-              <p className="listTitle bold">{item.category}</p>
-              <ul className="listWrap">
-                {item.list.map(list => (
-                  <li
-                    className="list"
-                    key={list.id}
-                    onClick={() => navigate(list.path)}
-                  >
-                    {list.data}
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ul>
-        <div className="dim" />
+          <h1 className="logo">로고이미지</h1>
+          <ul
+            className={`navListWrap${navActive ? ' active' : ''}`}
+            onMouseEnter={() => {
+              setNavActive(true);
+            }}
+          >
+            {NAV_LIST.map(item => (
+              <li className="navList" key={item.id}>
+                <p className="listTitle bold">{item.category}</p>
+                <ul className="listWrap">
+                  {item.list.map(list => (
+                    <li
+                      className="list"
+                      key={list.id}
+                      onClick={() => navigate(list.path)}
+                    >
+                      {list.data}
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+          <div className="dim" />
+        </div>
       </div>
-    </div>
+      {!isMainPage && <div className="virtualNav" />}
+    </>
   );
 };
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,15 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import './Nav.scss';
-import './navData';
+import { useNavigate } from 'react-router-dom';
 import NAV_LIST from './navData';
+import './Nav.scss';
 
 const Nav = () => {
+  const navigate = useNavigate();
   const [navActive, setNavActive] = useState(false);
   const [scrollY, setScrollY] = useState(0);
   const [scrollActive, setScrollActive] = useState(false);
 
   const scrollFixed = () => {
-    if (scrollY > 100) {
+    if (scrollY > 30) {
       setScrollY(window.pageYOffset);
       setScrollActive(true);
     } else {
@@ -51,22 +52,22 @@ const Nav = () => {
             setNavActive(true);
           }}
         >
-          {NAV_LIST.map(item => {
-            return (
-              <li className="navList" key={item.id}>
-                <p className="listTitle bold">{item.category}</p>
-                <ul className="listWrap">
-                  {item.list.map(list => {
-                    return (
-                      <li className="list" key={list.id}>
-                        {list.data}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </li>
-            );
-          })}
+          {NAV_LIST.map(item => (
+            <li className="navList" key={item.id}>
+              <p className="listTitle bold">{item.category}</p>
+              <ul className="listWrap">
+                {item.list.map(list => (
+                  <li
+                    className="list"
+                    key={list.id}
+                    onClick={() => navigate(list.path)}
+                  >
+                    {list.data}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
         </ul>
         <div className="dim" />
       </div>

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -1,4 +1,9 @@
 .nav {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+
   .navUtil {
     display: flex;
     justify-content: right;
@@ -178,6 +183,7 @@
     height: 108px;
     background: #000;
     z-index: 500;
+    transform: translateX(0);
 
     .navWrap {
       background: #000;

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -216,4 +216,5 @@
 
 .virtualNav {
   height: 148px;
+  margin-bottom: 30px;
 }

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -177,6 +177,7 @@
     width: 100%;
     height: 108px;
     background: #000;
+    z-index: 500;
 
     .navWrap {
       background: #000;

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -213,3 +213,7 @@
     }
   }
 }
+
+.virtualNav {
+  height: 148px;
+}

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -1,5 +1,5 @@
 .nav {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 50%;
   transform: translateX(-50%);
@@ -176,7 +176,6 @@
   }
 
   &.fixed {
-    position: fixed;
     top: -38px;
     left: 0;
     width: 100%;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- nav.js merge 후 하위 다른 컴포넌트 컨텐츠 내용 튀어 올라가는 현상 해결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. merge 후 깨지는 레이아웃 수정 (scss) commit : 95622c650a3284e108fc944705da5f0d68c3f6d5
- 처음에 잡았던 화면은 position 값을 아무것도 주지 않고 window의 특정 높이값까지 내려왔을때 position : fixed가 있는 스타일이 붙는 형태로 작업했습니다.
- merge 후 다른 팀원들 화면에서 제가 작업한 nav를 확인했을때 nav컨텐츠가 뒤로 밀려있어서 z-index값을 주었고 초기 default로 position을 주지 않아서 fixed가 붙을때마다 화면이 nav만큼 튀어올라가는 현상을 발견했습니다.
- 그래서 nav 자체 default를 position : fixed로 잡고 특정 높이값에 따라서 fixed가 되어도 안에 컨텐츠들은 튀어올라가지 않게 작업했습니다.
- 메인에서는 fixed 뒤에 영역이 있어야하고 다른 페이지에선 nav의 높이값 + 30px의 값이 있어야해서 래영님과 함께 고민해보고 useNavigation에 접근해서 path값을 가져오고 메인의 path값인 "/"일떄만 안보이게 작성을했습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- merge 하기 전에 여러가지 상황을 고려해서 테스트를 진행 해봤어야했는데 그 부분에서 조금 미흡했던 것 같습니다.

<br />

## :: 기타 질문 및 특이 사항
- fixed 가 갖고 있는 높이만큼 컨텐츠를 잡고 있는 곳을 margin-top이나 padding-top으로 띄워줘야하는데 팀원들이 작업한 페이지 각각 띄워줘야할까요 ?? -> 래영님께 여쭤보고 같이 상의 해서 수정했습니다 !
