### PR TITLE
[31기 김정수] Modify :공통 컴포넌트 footer 컴포넌트간 보기좋은 간격을 위한  margin-top값 수정 

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -7,7 +7,7 @@ import Main from './pages/Main/Main';
 import Menu from './pages/Menu/Menu';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer/Footer';
-// import Cart from './pages/Cart/Cart';
+import Cart from './pages/Cart/Cart';
 
 const Router = () => {
   return (
@@ -18,7 +18,7 @@ const Router = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/join" element={<Join />} />
         <Route path="/menu" element={<Menu />} />
-        {/* <Route path="/cart" element={<Cart />} /> */}
+        <Route path="/cart" element={<Cart />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/Router.js
+++ b/src/Router.js
@@ -7,7 +7,7 @@ import Main from './pages/Main/Main';
 import Menu from './pages/Menu/Menu';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer/Footer';
-import Cart from './pages/Cart/Cart';
+// import Cart from './pages/Cart/Cart';
 
 const Router = () => {
   return (
@@ -18,7 +18,7 @@ const Router = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/join" element={<Join />} />
         <Route path="/menu" element={<Menu />} />
-        <Route path="/cart" element={<Cart />} />
+        {/* <Route path="/cart" element={<Cart />} /> */}
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,6 +1,7 @@
 @import '../../styles/variables.scss';
 
 .footer {
+  margin-top: 80px;
   width: 100%;
   height: 210px;
   background-color: $mainColor;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

다른 컴포넌트와 딱 붙어서 나오는 점을 해결하기위해서 margin - top 값을 수정하였습니다. 
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

다른 컴포넌트와 딱 붙어서 나오는 점을 해결하기위해서 margin - top 값을 수정하였습니다. 

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

처음 머지했을때 position absolute값을 건들였을때와 비슷한 깨달음을 얻었습니다 메인만있었을때는 몰랐으나 

로그인 페이지가 합쳐지면서 해당 페이지와 간격이 없이 딱 붙어있는것을 보고 팀원들과 말해본 결과 공통컴포넌트인 푸터의 값을 변화시키는 것이 맞다는 결과로 변경하게되었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
