### PR TITLE
[31기 홍두현] FIX : nav 레이아웃 및 스타일 재설정, 로그인/회원가입 navigate연결

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -38,8 +38,8 @@ const Nav = () => {
     <>
       <div className={`nav${scrollActive ? ' fixed' : ''}`}>
         <ul className="navUtil inner">
-          <li>로그인</li>
-          <li>회원가입</li>
+          <li onClick={() => navigate('/login')}>로그인</li>
+          <li onClick={() => navigate('/join')}>회원가입</li>
           <li>
             <span className="instagram">인스타</span>
             <span className="facebook">페이스북</span>

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -51,7 +51,9 @@ const Nav = () => {
             setNavActive(false);
           }}
         >
-          <h1 className="logo">로고이미지</h1>
+          <h1 className="logo" onClick={() => navigate('/')}>
+            로고이미지
+          </h1>
           <ul
             className={`navListWrap${navActive ? ' active' : ''}`}
             onMouseEnter={() => {

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -2,6 +2,7 @@
   position: fixed;
   top: 0;
   left: 50%;
+  width: 100%;
   transform: translateX(-50%);
   z-index: 500;
 
@@ -13,6 +14,7 @@
       position: relative;
       font-size: 11px;
       padding: 9px 14px;
+      cursor: pointer;
 
       &:last-child {
         padding-right: 0;
@@ -70,7 +72,7 @@
       width: 100%;
       height: 0;
       background: #fff;
-      opacity: 0.5;
+      opacity: 0.8;
       z-index: 10;
       transition: height 0.2s ease-in-out;
     }
@@ -109,6 +111,7 @@
 
         .list {
           margin-bottom: 10px;
+          cursor: pointer;
 
           &:hover {
             text-decoration: underline;
@@ -179,14 +182,13 @@
   &.fixed {
     top: -38px;
     left: 0;
-    width: 100%;
     height: 108px;
     background: #000;
     transform: translateX(0);
 
     .navWrap {
       background: #000;
-      padding: 0 20px;
+      padding: 0;
 
       .logo {
         background: url(/assets/images/logo-s.png) no-repeat center center;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- nav에서 로그인, 회원가입 이동 기능
- 1200px 맞지 않는 이슈 fix
- 로고이미지 클릭시 메인페이지 이동 기능

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. nav에서 로그인과 회원가입 이동을 useNavigate()를 사용해서 넣어줬습니다.
2. 다른 페이지 컴포넌트의 총 너비 1200px과 맞지 않는 오류를 확인해서 scss 스타일 수정을 해줬습니다. 
3. 로고이미지 클릭시 메인페이지로 이동 가능하게 useNavigate를 이용해서 클릭시 '/'로 이동할수있게 작성했습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항

